### PR TITLE
fix typos in docs

### DIFF
--- a/slideshow-doc/scribblings/slideshow/guide.scrbl
+++ b/slideshow-doc/scribblings/slideshow/guide.scrbl
@@ -143,7 +143,7 @@ usually a pict, but there are a few other possibilities:
   @item{If an element is @racket['alts], then the next element must be
     a list of element lists. Each list up to the last one is appended
     to the elements before @racket['alts] and the resulting list of
-    elements is processed. The last lists is appended to the preceding
+    elements is processed. The last list is appended to the preceding
     elements along with the remaining elements (after the list of
     lists) and the result is re-processed.}
 

--- a/slideshow-doc/scribblings/slideshow/slides.scrbl
+++ b/slideshow-doc/scribblings/slideshow/slides.scrbl
@@ -269,14 +269,14 @@ Returns @racket[#t] if @racket[v] is a slide produced by
 
 @defproc[(most-recent-slide) slide?]{
 
-Returns a slide structure that be supplied @racket[re-slide] to make a
+Returns a slide structure that may be supplied to @racket[re-slide] to make a
 copy of the slide or @racket[slide->pict] to re-extract the entire
 slide as a pict.}
 
 @defproc[(retract-most-recent-slide) slide?]{
 
 Cancels the most recently created slide, and also returns a slide
-structure that be supplied to @racket[re-slide] to restore the slide
+structure that may be supplied to @racket[re-slide] to restore the slide
 (usually in a later position).}
 
 @defproc[(re-slide [slide slide?] [pict pict? (blank)])
@@ -310,8 +310,8 @@ Enables or disables slide advance as a result of a mouse click.}
 @defproc[(set-use-background-frame! [on? any/c]) void?]{
 
 Enables or disables the creation of a background frame, which is
-typically useful only when @racket[make-slide-inset] is used are
-active. The last enable/disable before the first slide registration
+typically useful only when @racket[make-slide-inset] is used.
+The last enable/disable before the first slide registration
 takes effect once and for all.}
 
 @defproc[(set-page-numbers-visible! [on? any/c]) void?]{

--- a/slideshow-doc/scribblings/slideshow/text.scrbl
+++ b/slideshow-doc/scribblings/slideshow/text.scrbl
@@ -1,6 +1,6 @@
 #lang scribble/manual
 
-@(require (for-label slideshow/base pict slideshow/text))
+@(require (for-label racket/list slideshow/base pict slideshow/text))
 
 @title{Text Formatting Helpers}
 


### PR DESCRIPTION
- "lists" -> "list"
- "be supplied" -> "may be supplied"
- "used are active." -> "used."
- and add a `for-label` so `cons` gets highlighted