### PR TITLE
doc: 'expect' -> 'accept'

### DIFF
--- a/slideshow-doc/scribblings/quick/quick.scrbl
+++ b/slideshow-doc/scribblings/quick/quick.scrbl
@@ -232,7 +232,7 @@ completely printing the function, so DrRacket just prints
 
 This example shows that functions are values, just like numbers and
 pictures (even if they don't print as nicely). Since functions are
-values, you can define functions that expect other functions as
+values, you can define functions that accept other functions as
 arguments:
 
 @ss-def+int[


### PR DESCRIPTION
As noted in https://github.com/racket/racket/issues/1750

(I think both are correct
 and 'expect' sounds more techically correct
 but 'accept' sounds better to say/read --- which may be clearer too ...
                                            the issue seems to imply that
                                            and I'd like to believe that)