### PR TITLE
Don't start elapsed timer unless command-line flag is present

### DIFF
--- a/slideshow-lib/slideshow/viewer.rkt
+++ b/slideshow-lib/slideshow/viewer.rkt
@@ -1156,16 +1156,16 @@
 	  (super-new)))
 
       (define elapsed-timer-tick
-        (if config:show-elapsed-time?
+        (when config:show-elapsed-time?
             (new timer%
                  [notify-callback (lambda ()
                                     (when (send c-both is-shown?)
                                       (send c-both redraw)))]
-                 [interval 1000])
-            (new timer% [interval 1000])))
+                 [interval 1000])))
 
       (define (stop-elapsed-timer!)
-        (send elapsed-timer-tick stop))
+        (when config:show-elapsed-time?
+          (send elapsed-timer-tick stop)))
 
       (define (paint-letterbox dc cw ch usw ush clip?)
 	(and (or (< usw cw)


### PR DESCRIPTION
@apg merging #11 caused tests in the nightly build to fail:
http://drdr.racket-lang.org/43864/racket/share/pkgs/slideshow-lib/texpict/symbol.rkt

The error is from a timeout. Before #11, running `racket file.rkt` on something like this would terminate:

```
(module a slideshow/slideshow)
```

and right now it just hangs.


This PR is one idea for a fix. With it, this command finishes (and so I'm pretty sure the nightly will pass).

```
$ raco test --drdr -c slideshow
```