### PR TITLE
Use `docname` library to avoid dependency on "web-server-doc".

### DIFF
--- a/slideshow-doc/info.rkt
+++ b/slideshow-doc/info.rkt
@@ -7,13 +7,12 @@
                      "gui-doc"
                      "pict-doc"
                      "scribble-doc"
-                     "web-server-doc"
                      "base"
                      "gui-lib"
                      "pict-lib"
                      "scribble-lib"
                      "slideshow-lib"
-                     "racket-doc"
+                     ["racket-doc" #:version "1.3"]
                      "at-exp-lib"))
 (define update-implies '("slideshow-lib"))
 

--- a/slideshow-doc/scribblings/quick/quick.scrbl
+++ b/slideshow-doc/scribblings/quick/quick.scrbl
@@ -10,6 +10,7 @@
           "mreval.rkt"
           "keep.rkt"
           scribble/urls
+          scribblings/private/docname
           scribble/struct
           racket/class
 
@@ -594,8 +595,7 @@ If you are new to programming or if you have the patience to work
 through a textbook, we recommend reading
 @italic{@link["http://www.htdp.org/"]{How to Design Programs}}. If you
 have already read it, or if you want to see where the book will take
-you, then see @other-manual['(lib
-"web-server/scribblings/tutorial/continue.scrbl")].
+you, then see @Continue[].
 
 For experienced programmers, to continue touring Racket from a
 systems-oriented perspective instead of pictures, your next stop is


### PR DESCRIPTION
Depends on racket/racket#3215.