### PR TITLE
Specify aspect for slideshow/play

### DIFF
--- a/slideshow-doc/scribblings/slideshow/play.scrbl
+++ b/slideshow-doc/scribblings/slideshow/play.scrbl
@@ -35,6 +35,7 @@ corresponds to an animation that fades in the word ``Hello.''
                [#:name name (or/c string? #f
                                   ((real-in 0.0 1.0) . -> . (or/c string? #f)))
                        title]
+               [#:aspect aspect aspect? #f]
                [#:comment comment (or/c comment? #f) #f]
                [#:layout layout (or/c 'auto 'center 'top 'tall) 'auto])
          void?]{
@@ -53,7 +54,7 @@ complete the animation and stop the auto-advance of slides. The
 If @racket[skip-first?] is @racket[#f], then one fewer slide is
 generated, because @racket[gen] is not called on @racket[0.0].
 
-The @racket[title], @racket[name], and @racket[layout] arguments are
+The @racket[title], @racket[name], @racket[aspect], and @racket[layout] arguments are
 passed on to @racket[slide], at least when @racket[title] and/or
 @racket[name] are not functions. When @racket[title] or @racket[name]
 is a function, the function is applied to the value used to produce
@@ -64,7 +65,9 @@ The @racket[comment] argument is used like a comment argument to
 @racket[slide].
 
 In condensed mode (i.e., when @racket[condense?] is @racket[#t]), any
-slide that would be registered with a timeout is instead skipped.}
+slide that would be registered with a timeout is instead skipped.
+
+@history[#:changed "1.7" @elem{Added the @racket[aspect] argument.}]}
 
 
 @defproc[(play-n [gen* (and/c (unconstrained-domain-> pict?)
@@ -81,6 +84,7 @@ slide that would be registered with a timeout is instead skipped.}
                  [#:name name (or/c string? #f
                                     ((real-in 0.0 1.0) . -> . (or/c string? #f)))
                          title]
+                 [#:aspect aspect aspect? #f]
                  [#:comments comment (list*of comment? (or/c comment? #f '())) #f]
                  [#:layout layout (or/c 'auto 'center 'top 'tall) 'auto])
           void?]{
@@ -127,9 +131,11 @@ and @racket[num_3] is used for the rest.
 The elements of the @racket[comment] argument are used like the @racket[steps]
 argument, except passed as comments instead of used as step counts.
 
-The @racket[delay-msecs], @racket[title],
-@racket[name], and @racket[layout] arguments are passed on to
-@racket[play] for each of the @math{n} segments of animation.}
+The @racket[delay-secs], @racket[title],
+@racket[name], @racket[aspect], and @racket[layout] arguments are passed on to
+@racket[play] for each of the @math{n} segments of animation.
+
+@history[#:changed "1.7" @elem{Added the @racket[aspect] argument.}]}
 
 
 @defproc[(animate-slide [element (flat-rec-contract elem/c

--- a/slideshow-lib/info.rkt
+++ b/slideshow-lib/info.rkt
@@ -13,7 +13,7 @@
 
 (define pkg-authors '(mflatt robby))
 
-(define version "1.6")
+(define version "1.7")
 
 (define license
   '(Apache-2.0 OR MIT))

--- a/slideshow-lib/slideshow/play.rkt
+++ b/slideshow-lib/slideshow/play.rkt
@@ -24,6 +24,7 @@
                       #:title 	
                       (or/c string? pict? #f
                             (-> (real-in 0.0 1.0) (or/c string? pict? #f)))
+                      #:aspect aspect?
                       #:name
                       (or/c string? #f
                             (-> (real-in 0.0 1.0) (or/c string? #f)))
@@ -37,6 +38,7 @@
                         #:title 	
                         (or/c string? pict? #f
                               (-> (real-in 0.0 1.0) (or/c string? pict? #f)))
+                        #:aspect aspect?
                         #:name
                         (or/c string? #f
                               (-> (real-in 0.0 1.0) (or/c string? #f)))
@@ -71,11 +73,13 @@
               #:delay [secs 0.05]
               #:skip-first? [skip-first? #f]
               #:comment [comment #f]
+              #:aspect [aspect #f]
               mid)
   (unless skip-first?
     (slide #:title (if (procedure? title) (title 0) title) 
            #:name (if (procedure? name) (name 0) name)
            #:layout layout
+
            (or comment 'nothing)
            (mid 0)))
   (if condense?
@@ -91,6 +95,7 @@
                #:name (if (procedure? name) (name n) name)
                #:layout layout
                #:timeout secs
+               #:aspect aspect
                (mid n)))))
 
 ;; Create a sequences of N `play' sequences, where `mid' takes
@@ -106,6 +111,7 @@
                 #:skip-last? [skip-last? #f]
                 #:skip-first? [skip-first? #f]
                 #:comments [comments #f]
+                #:aspect [aspect #f]
                 mid)
   (let ([n (procedure-arity mid)])
     (let loop ([post (vector->list (make-vector n))]
@@ -118,6 +124,7 @@
             (slide #:title (if (procedure? title) (apply title pre) title)
                    #:name (if (procedure? name) (apply name pre) name)
                    #:layout layout
+                   #:aspect aspect
                    (cond
                      [(or (null? comments) (not comments)) 'nothing]
                      [(pair? comments) (car comments)]
@@ -140,6 +147,7 @@
                                      (car comments)
                                      comments))
                   #:skip-first? skip?
+                  #:aspect aspect
                   (lambda (n)
                     (apply mid (append pre (list n) (cdr post)))))
             (loop (cdr post) (cons 1.0 pre) #f (if (pair? Ns) (cdr Ns) Ns)


### PR DESCRIPTION
I noticed that in my `slideshow/widescreen` application, slides created from `play` didn't have the right aspect. I solved this by allowing you to specify the aspect as an argument, but it would be nice if `#lang slideshow/widescreen` did this automatically as well (not sure the best way to do this).