### PR TITLE
Fix docname macro call

### DIFF
--- a/slideshow-doc/scribblings/quick/quick.scrbl
+++ b/slideshow-doc/scribblings/quick/quick.scrbl
@@ -595,7 +595,7 @@ If you are new to programming or if you have the patience to work
 through a textbook, we recommend reading
 @italic{@link["http://www.htdp.org/"]{How to Design Programs}}. If you
 have already read it, or if you want to see where the book will take
-you, then see @Continue[].
+you, then see @Continue[Continue-title].
 
 For experienced programmers, to continue touring Racket from a
 systems-oriented perspective instead of pictures, your next stop is


### PR DESCRIPTION
Without argument the `@Continue[]` macro expands to [the Continue: Web Applications in Racket documentation](https://docs.racket-lang.org/continue/index.html) (well actually to [theContinue: Web Applications in Racketdocumentation](https://docs.racket-lang.org/continue/index.html) but I will addressed upstream).

But here, we simply want [Continue: Web Applications in Racket](https://docs.racket-lang.org/continue/index.html) to stay consistent with the other links in this part (More and Racket Guide), see:

```
If you are new to programming or if you have the patience to work through a textbook, we recommend reading [How to Design Programs](http://www.htdp.org/). If you have already read it, or if you want to see where the book will take you, then see [theContinue: Web Applications in Racketdocumentation](https://docs.racket-lang.org/continue/index.html).

For experienced programmers, to continue touring Racket from a systems-oriented perspective instead of pictures, your next stop is [More: Systems Programming with Racket](https://docs.racket-lang.org/more/index.html).

To instead start learning about the full Racket language and tools in depth, move on to [The Racket Guide](https://docs.racket-lang.org/guide/index.html).
```

To fix this, it should be called like this `@Continue[Continue-title]` as in these other doc pages:

- [permalink to racket/pkgs/racket-doc/scribblings/getting-started/getting-started.scrbl](https://github.com/racket/racket/blob/18b766395ee4d1dfaff7ce33ed335bc29f828386/pkgs/racket-doc/scribblings/getting-started/getting-started.scrbl#L39-L40)

- [permalink to racket/pkgs/racket-doc/scribblings/more/more.scrbl](https://github.com/racket/racket/blob/18b766395ee4d1dfaff7ce33ed335bc29f828386/pkgs/racket-doc/scribblings/more/more.scrbl#L801-L804)

---

Please excuse me if I didn't use the right wording, I just discovered Racket yesterday.

Cheers :wave: 