### PR TITLE
get correct example path with collection-file-path

### DIFF
--- a/slideshow-exe/slideshow/tutorial-show.rkt
+++ b/slideshow-exe/slideshow/tutorial-show.rkt
@@ -609,9 +609,7 @@
 
 (require mred/edit)
 (define (show-example-code f)
-  (new-text-frame (path->string (build-path (collection-path "slideshow")
-                                            "examples"
-                                            f))))
+  (new-text-frame (path->string (collection-file-path f "slideshow" "examples"))))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Part IV


### PR DESCRIPTION
Commit 790efa4 (v3.99.0.2, 2007-11-13) corrected the paths for run-example-talk but not show-example-code. This commit updates show-example-code to also use collection-file-path; otherwise, we get a path in slideshow-lib that does not exist.